### PR TITLE
Help text/README updates, Additional minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # TLD Mythic Rating Helper
-Mythic Rating Helper is a discord bot which can be used to check a character's mythic runs, and return to them which dungeons would improve their overall mythic rating score. This version of Mythic Rating Helper has been modified from the original version and is currently intended for use within the Discord server for the World of Warcraft guild The Last Dynasty (US - Thrall).
+Mythic Rating Helper is a Discord bot which can provide information about completing Mythic+ dungeons at certain keystone levels and how that might impact a character's Mythic+ rating. This version of Mythic Rating Helper has been modified and is currently meant to work within the Discord server for the World of Warcraft guild The Last Dynasty (US - Thrall).
+
+Some operations this bot can perform:
+- Simulate a character running all Mythic+ dungeons at a single keystone level
+- Tell which dungeons a character could run to slightly improve their Mythic+ rating
+- Provide a plan for dungeons a character can complete to reach a goal Mythic+ rating
 
 ## TLD Links
 - [Raider.io](https://raider.io/guilds/us/thrall/The%20Last%20Dynasty)
 - [Warcraft Logs](https://www.warcraftlogs.com/guild/us/thrall/the%20last%20dynasty)
 - [WoW Armory](https://worldofwarcraft.blizzard.com/en-us/guild/us/thrall/the-last-dynasty)
-
-More to be added as development continues.
 
 The original version of Mythic Rating Helper can be found [here](https://github.com/Coryrin/mr-helper)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TLD Mythic Rating Helper
-Mythic Rating Helper is a Discord bot which can provide information about completing Mythic+ dungeons at certain keystone levels and how that might impact a character's Mythic+ rating. This version of Mythic Rating Helper has been modified and is currently meant to work within the Discord server for the World of Warcraft guild The Last Dynasty (US - Thrall).
+Mythic Rating Helper is a Discord bot which can provide information about completing Mythic+ dungeons at certain keystone levels and how that might impact a character's Mythic+ rating. This version of Mythic Rating Helper has been modified and is currently meant to work within the Discord server for the World of Warcraft guild The Last Dynasty (US - Thrall), **TLD Reforged**.
 
 Some operations this bot can perform:
 - Simulate a character running all Mythic+ dungeons at a single keystone level

--- a/helpers.js
+++ b/helpers.js
@@ -82,7 +82,7 @@ const getTargetKeystoneLevel = (highestRunDungeon, currentDungeon) => {
 
 const capitalizeWord = (word) => {
     if (!word) return '';
-    return word.charAt(0).toUpperCase() + word.substring(1)
+    return word.charAt(0).toUpperCase() + word.substring(1);
 }
 
 module.exports = {

--- a/helpers.js
+++ b/helpers.js
@@ -80,8 +80,14 @@ const getTargetKeystoneLevel = (highestRunDungeon, currentDungeon) => {
     return targetLevel;
 }
 
+const capitalizeWord = (word) => {
+    if (!word) return '';
+    return word.charAt(0).toUpperCase() + word.substring(1)
+}
+
 module.exports = {
     getDungeonScore,
     getTargetKeystoneLevel,
+    capitalizeWord,
     dungeonShortnameMap
 }


### PR DESCRIPTION
- Updated text output by `/mr-helper help` to be useful to users
- Updated README.md
- Restrictions added to certain input fields
  - Minimum value for simulated keystone level and goal M+ rating
  - Minimum and maximum length for character names
- Sanitize realm name if provided to account for apostrophes and spaces (eg. Kel'Thuzad, Area 52)
- Added helper function to capitalize words